### PR TITLE
Add msbuild pipe logger

### DIFF
--- a/src/dotnet-releaser/dotnet-releaser.csproj
+++ b/src/dotnet-releaser/dotnet-releaser.csproj
@@ -54,7 +54,7 @@
     <PackageReference Include="NuGet.Versioning" Version="6.0.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Scriban" Version="5.4.0" />
-    <PackageReference Include="Tomlyn" Version="0.10.2" />
+    <PackageReference Include="Tomlyn" Version="0.11.0" />
     <PackageReference Include="CliWrap" Version="3.4.1" />
   </ItemGroup>
 </Project>

--- a/src/dotnet-releaser/dotnet-releaser.csproj
+++ b/src/dotnet-releaser/dotnet-releaser.csproj
@@ -44,13 +44,26 @@
   <ItemGroup>
     <PackageReference Include="DotNet.Glob" Version="3.1.3" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
+    <PackageReference Include="Microsoft.Build" Version="16.10.0">
+      <NoWarn>NU1608</NoWarn>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.10.0">
+      <NoWarn>NU1608</NoWarn>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.10.0">
+      <NoWarn>NU1608</NoWarn>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0">
+      <NoWarn>NU1608</NoWarn>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="MinVer" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.630" GeneratePathProperty="true" />
+    <PackageReference Include="MsBuildPipeLogger.Logger" Version="1.1.3" />
+    <PackageReference Include="MsBuildPipeLogger.Server" Version="1.1.3" />
     <PackageReference Include="NuGet.Versioning" Version="6.0.0" />
     <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Scriban" Version="5.4.0" />

--- a/src/dotnet-releaser/dotnet-releaser.csproj
+++ b/src/dotnet-releaser/dotnet-releaser.csproj
@@ -43,7 +43,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotNet.Glob" Version="3.1.3" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="MinVer" Version="2.5.0">


### PR DESCRIPTION
Remove usage of StructuredLogger in favor of [MSBuildPipeLogger](https://github.com/daveaglick/MsBuildPipeLogger) from @daveaglick to allow instant log feedback when running long builds.

Bump also a few dependencies.