### PR TITLE
Improve `dotnet-releaser new` command

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -699,9 +699,12 @@ Arguments:
   dotnet-releaser.toml      TOML configuration file path to create. Default is: dotnet-releaser.toml
 
 Options:
-  --project <project_file>  A - relative - path to project file (csproj, vbproj, fsproj)
-  --user <GitHub_user/org>  The GitHub user/org where the packages will be published
-  --repo <GitHub_repo>      The GitHub repo name where the packages will be published
+  --project <project_file>  A - relative - path to a solution file (.sln) or project file (.csproj, .fsproj, .vbproj). By default, it will try to find a solution file where this command is run or where the output dotnet-releaser.toml file
+                            is specified.
+  --user <GitHub_user/org>  The GitHub user/org where the packages will be published. If not specified, it will try to detect automatically if there is a git repository configured from the folder (and parents) of the TOML configuration
+                            file, and extract any git remote that could give this information.
+  --repo <GitHub_repo>      The GitHub repo name where the packages will be published. If not specified, it will try to detect automatically if there is a git repository configured from the folder (and parents) of the TOML configuration
+                            file, and extract any git remote that could give this information.
   --force                   Force overwriting the existing TOML configuration file.
   -?|-h|--help              Show help information.
 ```

--- a/readme.md
+++ b/readme.md
@@ -53,17 +53,21 @@ By default, `dotnet-releaser` will:
 > See the [user guide](https://github.com/xoofx/dotnet-releaser/blob/main/doc/readme.md) on how to setup this differently for your application.
 ## Getting Started
 
-- Create a `dotnet-releaser.toml` at the same level you have your .NET solution. Most projects won't need more than this kind of configuration:
+- Install `dotnet-releaser` as a global .NET tool.
+  ```
+  dotnet tool install --global dotnet-releaser"
+  ```
+- Go to a folder where you have your solution `.sln` file or your project file (`.csproj`, `.fsproj`, `.vbproj`) and run:
+  ```
+  dotnet releaser new
+  ```
+- It should create a `dotnet-releaser.toml` at the same level than your solution with a content like:
   ```toml
   [msbuild]
   project = "Tonlyn.sln"
   [github]
   user = "xoofx"
   repo = "Tomlyn"
-  ```
-- Install `dotnet-releaser` as a global .NET tool.
-  ```
-  dotnet tool install --global dotnet-releaser"
   ```
 - If you want to try a full build locally:
   ```

--- a/src/dotnet-releaser/ReleaserApp.New.cs
+++ b/src/dotnet-releaser/ReleaserApp.New.cs
@@ -1,14 +1,20 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using LibGit2Sharp;
 
 namespace DotNetReleaser;
 
 public partial class ReleaserApp
 {
+    //                 (1)          (2)
+    // git@github.com:xoofx/dotnet-releaser.git
+    private static readonly Regex GitUrlRegex = new Regex(@":(.+)/(.+)\.git");
 
-    private async Task<bool> CreateConfigurationFile(string? destinationFilePath, string projectFile, string? user, string? repo, bool force)
+    private async Task<bool> CreateConfigurationFile(string? destinationFilePath, string? projectFile, string? user, string? repo, bool force)
     {
         destinationFilePath ??= Path.Combine(Environment.CurrentDirectory, "dotnet-releaser.toml");
         destinationFilePath = Path.Combine(Environment.CurrentDirectory, destinationFilePath);
@@ -18,12 +24,58 @@ public partial class ReleaserApp
             return false;
         }
 
+        var folder = Path.GetDirectoryName(destinationFilePath)!;
+        if (projectFile is null)
+        {
+            projectFile = Directory.GetFiles(folder).FirstOrDefault(x => x.EndsWith(".sln"));
+            if (projectFile is null)
+            {
+                Error($"Unable to find a solution file in the folder {folder}");
+                return false;
+            }
+
+            projectFile = Path.GetFileName(projectFile);
+        }
+
+        var repositoryPath = Repository.Discover(Path.GetDirectoryName(destinationFilePath));
+        if (repositoryPath is not null && user is null && repo is null)
+        {
+            var repository = new Repository(repositoryPath);
+            foreach (var remote in repository.Network.Remotes)
+            {
+                var url = remote.Url;
+                if (url.StartsWith("git"))
+                {
+                    var match = GitUrlRegex.Match(url);
+                    if (match.Success)
+                    {
+                        user = match.Groups[1].Value;
+                        repo = match.Groups[2].Value;
+                        break;
+                    }
+                }
+                else if (url.StartsWith("http"))
+                {
+                    // https://github.com/xoofx/dotnet-releaser.git
+                    var uri = new Uri(url);
+                    var path = uri.PathAndQuery;
+                    user = Path.GetFileName(Path.GetDirectoryName(path));
+                    repo = Path.GetFileNameWithoutExtension(path);
+                    break;
+                }
+            }
+        }
+
+        user ??= "github_user_or_org_here";
+        repo ??= "github_repo_here";
+        
+
         var configAsText = $@"# configuration file for dotnet-releaser
 [msbuild]
 project = ""{projectFile.Replace('\\', '/')}""
 [github]
-user = ""{user ?? "github_user_or_org_here"}""
-repo = ""{repo ?? "github_repo_here"}""
+user = ""{user}""
+repo = ""{repo}""
 ";
 
         // Normalize the output

--- a/src/dotnet-releaser/ReleaserApp.cs
+++ b/src/dotnet-releaser/ReleaserApp.cs
@@ -132,7 +132,7 @@ public partial class ReleaserApp
             {
                 newCommand.Description = "Create a dotnet-releaser TOML configuration file for a specified project.";
                 var configurationFileArg = AddTomlConfigurationArgument(newCommand, true);
-                var projectOption = newCommand.Option<string>("--project <project_file>", "A - relative - path to project file (csproj, vbproj, fsproj)", CommandOptionType.SingleValue).IsRequired();
+                var projectOption = newCommand.Option<string>("--project <project_file>", "A - relative - path to a solution file (sln) or project file (csproj, vbproj, fsproj). By default, it will try to find a solution file where this command is run or where the output dotnet-releaser.toml file is specified.", CommandOptionType.SingleValue);
                 var userOption = newCommand.Option<string>("--user <GitHub_user/org>", "The GitHub user/org where the packages will be published", CommandOptionType.SingleValue);
                 var repoOption = newCommand.Option<string>("--repo <GitHub_repo>", "The GitHub repo name where the packages will be published", CommandOptionType.SingleValue);
                 var forceOption = newCommand.Option<bool>("--force", "Force overwriting the existing TOML configuration file.", CommandOptionType.NoValue);

--- a/src/dotnet-releaser/ReleaserApp.cs
+++ b/src/dotnet-releaser/ReleaserApp.cs
@@ -132,9 +132,9 @@ public partial class ReleaserApp
             {
                 newCommand.Description = "Create a dotnet-releaser TOML configuration file for a specified project.";
                 var configurationFileArg = AddTomlConfigurationArgument(newCommand, true);
-                var projectOption = newCommand.Option<string>("--project <project_file>", "A - relative - path to a solution file (sln) or project file (csproj, vbproj, fsproj). By default, it will try to find a solution file where this command is run or where the output dotnet-releaser.toml file is specified.", CommandOptionType.SingleValue);
-                var userOption = newCommand.Option<string>("--user <GitHub_user/org>", "The GitHub user/org where the packages will be published", CommandOptionType.SingleValue);
-                var repoOption = newCommand.Option<string>("--repo <GitHub_repo>", "The GitHub repo name where the packages will be published", CommandOptionType.SingleValue);
+                var projectOption = newCommand.Option<string>("--project <project_file>", "A - relative - path to a solution file (.sln) or project file (.csproj, .fsproj, .vbproj). By default, it will try to find a solution file where this command is run or where the output dotnet-releaser.toml file is specified.", CommandOptionType.SingleValue);
+                var userOption = newCommand.Option<string>("--user <GitHub_user/org>", "The GitHub user/org where the packages will be published. If not specified, it will try to detect automatically if there is a git repository configured from the folder (and parents) of the TOML configuration file, and extract any git remote that could give this information.", CommandOptionType.SingleValue);
+                var repoOption = newCommand.Option<string>("--repo <GitHub_repo>", "The GitHub repo name where the packages will be published. If not specified, it will try to detect automatically if there is a git repository configured from the folder (and parents) of the TOML configuration file, and extract any git remote that could give this information.", CommandOptionType.SingleValue);
                 var forceOption = newCommand.Option<bool>("--force", "Force overwriting the existing TOML configuration file.", CommandOptionType.NoValue);
 
                 newCommand.OnExecuteAsync(async token =>


### PR DESCRIPTION
By detecting automatically solution/project files and git remote user/repo.