### PR TITLE
bug: Check if coverage is enabled before running coverage logic

### DIFF
--- a/src/dotnet-releaser/ReleaserApp.BuildAndTests.cs
+++ b/src/dotnet-releaser/ReleaserApp.BuildAndTests.cs
@@ -79,7 +79,11 @@ public partial class ReleaserApp
 
             if (groupLogged)
             {
-                LoadAndDisplayCoverageResults();
+                if (_config.Coverage.Enable)
+                {
+                    LoadAndDisplayCoverageResults();
+                }
+
                 _logger.LogEndGroup();
             }
         }


### PR DESCRIPTION
Issue: #38 

Only run coverage result method when coverage is enabled