### PR TITLE
Add support for publishing scoop manifests

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -23,10 +23,11 @@
   - [2.7. Packaging](#27-packaging)
   - [2.8. NuGet](#28-nuget)
   - [2.9. Homebrew](#29-homebrew)
-  - [2.10. Changelog](#210-changelog)
-  - [2.11. Service](#211-service)
-    - [2.11.1. Systemd](#2111-systemd)
-  - [2.12. Package Dependencies](#212-package-dependencies)
+  - [2.10. Scoop](#210-scoop)
+  - [2.11. Changelog](#211-changelog)
+  - [2.12. Service](#212-service)
+    - [2.12.1. Systemd](#2121-systemd)
+  - [2.13. Package Dependencies](#213-package-dependencies)
 - [3. CLI Usage](#3-cli-usage)
   - [3.1. `dotnet-releaser new`](#31-dotnet-releaser-new)
   - [3.2. `dotnet-releaser build`](#32-dotnet-releaser-build)
@@ -545,6 +546,7 @@ For example:
 source = "https://my.special.registry.nuget.org/v3/index.json"
 # publish = false
 ```
+
 ### 2.9. Homebrew
 
 By default, a Homebrew repository and formula will be created if a `tar` file is generated for either a Linux or MacOS platform.
@@ -575,7 +577,31 @@ See for example the generated [Homebrew repository for grpc-curl](https://github
 > 
 > By default the `${{secrets.GITHUB_TOKEN}}` is only valid to interact with the current repository.
 
-### 2.10. Changelog
+### 2.10. Scoop
+
+By default, a Scoop repository (bucket) and manifest will be created if a `zip` file is generated for the Windows platform.
+
+| `[scoop]`       | Type       | Description                |
+|-----------------|------------|----------------------------|
+| `publish`       | `bool`     | Enable or disable Scoop support. Default is enabled.
+| `home`          | `string`   | Allow to override the default scoop repository name. See more details below.
+
+By default, if your application name is `my-application`, and your GitHub user `xyz`, it will create and update automatically a repository at `https://github.com/xyz/scoop-my-application`.
+
+If you want to change this default behavior, and use your own scoop bucket, you can specify it by setting `home`:
+
+```toml
+[scoop]
+home = "scoop-all-my-apps"
+```
+
+This repository will be created using the [Scoop bucket template](https://github.com/ScoopInstaller/BucketTemplate).
+
+> NOTE: In order to create and publish to a different repository, you will need to create a personal access GitHub Token and pass it to `--github-token-extra`.
+>
+> By default the `${{secrets.GITHUB_TOKEN}}` is only valid to interact with the current repository.
+
+### 2.11. Changelog
 
 `dotnet-releaser` comes with great defaults that can generate automatically your changelog from your commits and pull-requests.
 
@@ -583,7 +609,7 @@ The generated changelog can then be uploaded as part of the publish process when
 
 Please follow the dedicated [user-guide for configuring changelog](changelog_user_guide.md).
 
-### 2.11. Service
+### 2.12. Service
 
 `dotnet-releaser` allows to package an application as a service that can be be automatically started by the platform supporting such kind of packages.
 
@@ -598,7 +624,7 @@ publish = true # Allow to package the application as a service for the packages 
 
 Then for each kind of service system, your application might require specific configuration.
 
-#### 2.11.1. Systemd
+#### 2.12.1. Systemd
 
 An example of a specific configuration for a systemd service
 
@@ -649,7 +675,7 @@ Type = simple
 
 See the [Systemd configuration manual](https://manpages.debian.org/bullseye-backports/systemd/systemd.unit.5.en.html) for the meaning of these defaults.
 
-### 2.12. Package Dependencies
+### 2.13. Package Dependencies
 
 It is possible to define package dependencies if the underlying package model supports it.
 
@@ -747,7 +773,9 @@ $ dotnet-releaser build --project HelloWorld.csproj --user xoofx --repo HelloWor
 
 ### 3.3. `dotnet-releaser publish`
 
-```
+> NOTE: this command fails if the release assets have been already uploaded; use `--force-upload` to replace them.
+
+```text
 Build and publish the project.
 
 Usage: dotnet-releaser publish [options] <dotnet-releaser.toml>
@@ -765,6 +793,7 @@ Options:
                                 Markdown.
                                 Default value is: Square.
   --force                       Force deleting and recreating the artifacts folder.
+  --force-upload                Force uploading the release assets.
   -?|-h|--help                  Show help information.
 ```
 

--- a/src/DotNetReleaser.Tests/MockDevHosting.cs
+++ b/src/DotNetReleaser.Tests/MockDevHosting.cs
@@ -60,6 +60,11 @@ public class MockDevHosting : IDevHosting
         return Task.CompletedTask;
     }
 
+    public Task UploadScoopManifest(string user, string repo, ProjectPackageInfo projectPackageInfo, string scoopManifest)
+    {
+        return Task.CompletedTask;
+    }
+
     private static readonly Regex VersionRegex = new(@"^\d+(\.\d+)+");
 
     public string GetCompareUrl(string user, string repo, string fromRef, string toRef)

--- a/src/DotNetReleaser.Tests/MockDevHosting.cs
+++ b/src/DotNetReleaser.Tests/MockDevHosting.cs
@@ -50,7 +50,7 @@ public class MockDevHosting : IDevHosting
 
 
 
-    public Task UpdateChangelogAndUploadPackages(string user, string repo, ReleaseVersion version, ChangelogResult? changelog, List<AppPackageInfo> entries, bool enablePublishPackagesInDraft)
+    public Task UpdateChangelogAndUploadPackages(string user, string repo, ReleaseVersion version, ChangelogResult? changelog, List<AppPackageInfo> entries, bool enablePublishPackagesInDraft, bool forceUpload)
     {
         return Task.CompletedTask;
     }

--- a/src/dotnet-releaser/Configuration/ReleaserConfiguration.cs
+++ b/src/dotnet-releaser/Configuration/ReleaserConfiguration.cs
@@ -26,6 +26,7 @@ public class ReleaserConfiguration
         GitHub = new GitHubDevHostingConfiguration();
         NuGet = new NuGetPublisher();
         Brew = new BrewPublisher();
+        Scoop = new ScoopPublisher();
         Service = new ServiceConfiguration();
         Debian = new DebianConfiguration();
         Rpm = new RpmConfiguration();
@@ -57,6 +58,8 @@ public class ReleaserConfiguration
     public NuGetPublisher NuGet { get; }
 
     public BrewPublisher Brew { get; }
+
+    public ScoopPublisher Scoop { get; set; }
 
     /// <summary>
     /// Configuration for service

--- a/src/dotnet-releaser/Configuration/ScoopPublisher.cs
+++ b/src/dotnet-releaser/Configuration/ScoopPublisher.cs
@@ -1,0 +1,11 @@
+﻿namespace DotNetReleaser.Configuration;
+
+public class ScoopPublisher : ConfigurationBase
+{
+    public ScoopPublisher()
+    {
+        Home = string.Empty;
+    }
+
+    public string Home { get; set; }
+}

--- a/src/dotnet-releaser/DevHosting/GitHubDevHosting.cs
+++ b/src/dotnet-releaser/DevHosting/GitHubDevHosting.cs
@@ -353,8 +353,8 @@ public class GitHubDevHosting : IDevHosting
             var filename = Path.GetFileName(entry.Path);
             if (assets.Any(x => x.Name == filename) && !forceUpload)
             {
-                _log.Error($"{entry.Path} has already been uploaded. Use --force-upload to replace it.");
-                return;
+                _log.Warning($"{entry.Path} has already been uploaded. Use --force-upload to replace it.");
+                continue;
             }
 
             const int maxHttpRetry = 10;

--- a/src/dotnet-releaser/DevHosting/GitHubDevHosting.cs
+++ b/src/dotnet-releaser/DevHosting/GitHubDevHosting.cs
@@ -353,7 +353,7 @@ public class GitHubDevHosting : IDevHosting
             var filename = Path.GetFileName(entry.Path);
             if (assets.Any(x => x.Name == filename) && !forceUpload)
             {
-                _log.Warning($"{entry.Path} has already been uploaded. Use --force-upload to replace it.");
+                _log.Info($"{entry.Path} has already been uploaded. Use --force-upload to replace it.");
                 continue;
             }
 

--- a/src/dotnet-releaser/IDevHosting.cs
+++ b/src/dotnet-releaser/IDevHosting.cs
@@ -30,7 +30,7 @@ public interface IDevHosting
 
     Task CreateOrUpdateRelease(string user, string repo, ReleaseVersion version, ChangelogResult? changelog);
 
-    Task UpdateChangelogAndUploadPackages(string user, string repo, ReleaseVersion version, ChangelogResult? changelog, List<AppPackageInfo> entries, bool enablePublishPackagesInDraft);
+    Task UpdateChangelogAndUploadPackages(string user, string repo, ReleaseVersion version, ChangelogResult? changelog, List<AppPackageInfo> entries, bool enablePublishPackagesInDraft, bool forceUpload);
 
     Task UploadHomebrewFormula(string user, string repo, ProjectPackageInfo projectPackageInfo, string brewFormula);
     

--- a/src/dotnet-releaser/IDevHosting.cs
+++ b/src/dotnet-releaser/IDevHosting.cs
@@ -33,6 +33,8 @@ public interface IDevHosting
     Task UpdateChangelogAndUploadPackages(string user, string repo, ReleaseVersion version, ChangelogResult? changelog, List<AppPackageInfo> entries, bool enablePublishPackagesInDraft);
 
     Task UploadHomebrewFormula(string user, string repo, ProjectPackageInfo projectPackageInfo, string brewFormula);
+    
+    Task UploadScoopManifest(string user, string repo, ProjectPackageInfo projectPackageInfo, string scoopManifest);
 
     string GetCompareUrl(string user, string repo, string fromRef, string toRef);
 

--- a/src/dotnet-releaser/ReleaserApp.Publishing.cs
+++ b/src/dotnet-releaser/ReleaserApp.Publishing.cs
@@ -6,7 +6,8 @@ namespace DotNetReleaser;
 
 public partial class ReleaserApp
 {
-    private async Task PublishPackagesAndChangelog(string? nugetApiToken, BuildInformation buildInformation, GitHubDevHostingConfiguration hostingConfiguration, IDevHosting? devHosting, IDevHosting? devHostingExtra, ChangelogResult? changelog)
+    private async Task PublishPackagesAndChangelog(string? nugetApiToken, BuildInformation buildInformation, GitHubDevHostingConfiguration hostingConfiguration,
+        IDevHosting? devHosting, IDevHosting? devHostingExtra, ChangelogResult? changelog, bool forceUpload)
     {
         bool groupStarted = false;
         try
@@ -32,7 +33,7 @@ public partial class ReleaserApp
                     var appPackagesToPublish = buildPackageInformation.AppPackages;
 
                     // In the case of a build, we still want to upload a draft release notes
-                    await devHosting.UpdateChangelogAndUploadPackages(hostingConfiguration.User, hostingConfiguration.Repo, releaseVersion, changelog, appPackagesToPublish, _config.EnablePublishPackagesInDraft);
+                    await devHosting.UpdateChangelogAndUploadPackages(hostingConfiguration.User, hostingConfiguration.Repo, releaseVersion, changelog, appPackagesToPublish, _config.EnablePublishPackagesInDraft, forceUpload);
 
                     if (!HasErrors && _config.Brew.Publish)
                     {

--- a/src/dotnet-releaser/ReleaserApp.Publishing.cs
+++ b/src/dotnet-releaser/ReleaserApp.Publishing.cs
@@ -49,6 +49,22 @@ public partial class ReleaserApp
                             await devHostingExtra.UploadHomebrewFormula(hostingConfiguration.User, _config.Brew.Home, packageInfo, brewFormula);
                         }
                     }
+                    
+                    if (!HasErrors && _config.Scoop.Publish)
+                    {
+                        // Log an error if we don't have an extra access for homebrew
+                        devHostingExtra ??= devHosting;
+                        var scoopManifest = CreateScoopManifest(devHostingExtra, packageInfo, appPackagesToPublish);
+
+                        if (scoopManifest is not null)
+                        {
+                            if (devHostingExtra == devHosting)
+                            {
+                                Warn("Warning, publishing a new Scoop manifest requires to use --github-token-extra. Using --github-token as a fallback but it might fail!");
+                            }
+                            await devHostingExtra.UploadScoopManifest(hostingConfiguration.User, _config.Scoop.Home, packageInfo, scoopManifest);
+                        }
+                    }
                 }
             }
         }

--- a/src/dotnet-releaser/ReleaserApp.Scoop.cs
+++ b/src/dotnet-releaser/ReleaserApp.Scoop.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using DotNetReleaser.Helpers;
+
+namespace DotNetReleaser;
+
+public partial class ReleaserApp
+{
+    private void UpdateScoopConfigurationFromPackage(ProjectPackageInfo projectPackageInfo)
+    {
+        if (!_config.Scoop.Publish) return;
+
+        _config.Scoop.Home = string.IsNullOrEmpty(_config.Scoop.Home) ? $"scoop-{projectPackageInfo.AssemblyName}" : _config.Scoop.Home;
+
+        Info($"The configured scoop destination repository is `{_config.GitHub.User}/{_config.Scoop.Home}`.");
+    }
+
+    private string? CreateScoopManifest(IDevHosting hosting, ProjectPackageInfo projectPackageInfo, List<AppPackageInfo> appPackagesToPublish)
+    {
+        var entriesForScoop = new List<(AppPackageInfo, string)>();
+        foreach (var packageInfo in appPackagesToPublish)
+        {
+            var architecture = GetScoopArchitecture(packageInfo.RuntimeId);
+            if (packageInfo.Kind == PackageKind.Zip && architecture is not null)
+            {
+                entriesForScoop.Add((packageInfo, architecture));
+            }
+        }
+
+        if (entriesForScoop.Count == 0)
+        {
+            return null;
+        }
+
+        UpdateScoopConfigurationFromPackage(projectPackageInfo);
+
+        var appName = projectPackageInfo.AssemblyName;
+        var manifestBuilder = new StringBuilder();
+
+        manifestBuilder.AppendLine($@"{{
+    ""homepage"": ""{projectPackageInfo.ProjectUrl}"",
+    ""license"": ""{projectPackageInfo.License}"",
+    ""description"": ""{projectPackageInfo.Description}"",
+    ""version"": ""{projectPackageInfo.Version}"",
+    ""architecture"": {{");
+
+        var entries = entriesForScoop.Where(x => x.Item1.RuntimeId.StartsWith("win-")).ToArray();
+        for (var i = 0; i < entries.Length; i++)
+        {
+            var (packageEntry, arch) = entries[i];
+            manifestBuilder.Append($@"        ""{arch}"": {{
+            ""url"": ""{hosting.GetDownloadReleaseUrl(projectPackageInfo.Version, Path.GetFileName(packageEntry.Path))}"",
+            ""hash"": ""{packageEntry.Sha256}""
+        }}");
+
+            if (i < entries.Length - 1)
+            {
+                manifestBuilder.AppendLine(",");
+            }
+            else
+            {
+                manifestBuilder.AppendLine();
+            }
+        }
+
+        manifestBuilder.AppendLine($@"    }},
+    ""bin"": ""{appName}.exe""
+}}").AppendLine();
+
+        return manifestBuilder.ToString().Replace("\r\n", "\n");
+    }
+
+    private static string? GetScoopArchitecture(string rid) => rid switch
+    {
+        "win-x64" => "64bit",
+        "win-x86" => "32bit",
+        _ => null
+    };
+}

--- a/src/dotnet-releaser/dotnet-releaser.csproj
+++ b/src/dotnet-releaser/dotnet-releaser.csproj
@@ -68,7 +68,7 @@
     <PackageReference Include="MsBuildPipeLogger.Server" Version="1.1.6" />
     <PackageReference Include="NuGet.Frameworks" Version="6.1.0" />
     <PackageReference Include="NuGet.Versioning" Version="6.1.0" />
-    <PackageReference Include="Octokit" Version="0.50.0" />
+    <PackageReference Include="Octokit" Version="2.0.1" />
     <PackageReference Include="Scriban" Version="5.4.2" />
     <PackageReference Include="Spectre.Console" Version="0.44.0" />
     <PackageReference Include="Tomlyn" Version="0.14.0" />


### PR DESCRIPTION
Closes #37
Closes #45 

Add support for publishing Scoop manifests in a way similar to how it's done for Homebrew formulas.
Scoop provides a repository template for new buckets, so I updated the Oktokit dependency to the latest version in order to be able to create the new bucket using that template.

The original behavior of the `publish` command is to skip uploaded release assets if one asset with the same name is already attached to the release being updated. 
This causes the subsequent generation of the scoop manifest to use a SHA256 of the assets that's different from the one attached to the release making the manifest invalid.

To remedy this problem I added a `--force-upload` option to the `publish` command: when not specified the command will fail if there are already uploaded assets.

The documentation has been updated accordingly.