### PR TITLE
Use .NET built-in Tar and Zip handling

### DIFF
--- a/src/dotnet-releaser/Helpers/CompressionHelper.cs
+++ b/src/dotnet-releaser/Helpers/CompressionHelper.cs
@@ -1,0 +1,51 @@
+﻿using System.Formats.Tar;
+using System.IO;
+using System.IO.Compression;
+
+namespace DotNetReleaser.Helpers;
+
+internal static class CompressionHelper
+{
+    public static string? MakeTarGz(ProjectPackageInfo projectPackageInfo, string publishDir, string artifactsFolder, string rid)
+    {
+        string? outputPath = null;
+        var publishPath = Path.Combine(Path.GetDirectoryName(projectPackageInfo.ProjectFullPath) ?? "", publishDir);
+        if (Directory.Exists(publishPath))
+        {
+            var gzipPath = Path.GetFullPath(Path.Combine(artifactsFolder, 
+                projectPackageInfo.Name + "." + projectPackageInfo.Version + "." + rid + ".tar.gz"));
+            if (File.Exists(gzipPath))
+            {
+                return null; // file already exists
+            }
+            using FileStream fs = new(gzipPath, FileMode.CreateNew, FileAccess.Write);
+            using GZipStream gz = new(fs, CompressionMode.Compress, leaveOpen: true);
+            {
+                TarFile.CreateFromDirectory(publishPath, gz, includeBaseDirectory: false);
+            }
+            outputPath = gzipPath;
+        }
+        return outputPath;
+    }
+
+    public static string? MakeZip(ProjectPackageInfo projectPackageInfo, string publishDir, string artifactsFolder, string rid)
+    {
+        string? outputPath = null;
+        var publishPath = Path.Combine(Path.GetDirectoryName(projectPackageInfo.ProjectFullPath) ?? "", publishDir);
+        if (Directory.Exists(publishPath))
+        {
+            var zipPath = Path.GetFullPath(Path.Combine(artifactsFolder, 
+                projectPackageInfo.Name + "." + projectPackageInfo.Version + "." + rid + ".zip"));
+            if (File.Exists(zipPath))
+            {
+                return null; // file already exists
+            }
+            using FileStream fs = new(zipPath, FileMode.CreateNew, FileAccess.Write);
+            {
+                ZipFile.CreateFromDirectory(publishPath, fs, compressionLevel: CompressionLevel.Optimal, includeBaseDirectory: false);
+            }
+            outputPath = zipPath;
+        }
+        return outputPath;
+    }
+}

--- a/src/dotnet-releaser/ReleaserApp.AppPackaging.cs
+++ b/src/dotnet-releaser/ReleaserApp.AppPackaging.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using DotNetReleaser.Configuration;
+using DotNetReleaser.Helpers;
 using DotNetReleaser.Logging;
 using Spectre.Console;
 
@@ -225,7 +226,28 @@ public partial class ReleaserApp
 
             // Copy the file to the output
             var path = result[0].ItemSpec;
-            path = CopyToArtifacts(path);
+            if (target == ReleaserConstants.DotNetReleaserPublishAndCreateTar)
+            {
+                path = CompressionHelper.MakeTarGz(projectPackageInfo, path, _config.ArtifactsFolder, rid);
+                if (path is null)
+                {
+                    Error("Unable to make tar file with publish directory " + path + "; does the file already exist?");
+                    break;
+                }
+            }
+            else if (target == ReleaserConstants.DotNetReleaserPublishAndCreateZip)
+            {
+                path = CompressionHelper.MakeZip(projectPackageInfo, path, _config.ArtifactsFolder, rid);
+                if (path is null)
+                {
+                    Error("Unable to make zip file with publish directory " + path + "; does the file already exist?");
+                    break;
+                }
+            }
+            else
+            {
+                path = CopyToArtifacts(path);
+            }
 
             var sha256 = string.Join("", SHA256.HashData(await File.ReadAllBytesAsync(path)).Select(x => x.ToString("x2")));
 

--- a/src/dotnet-releaser/dotnet-releaser.targets
+++ b/src/dotnet-releaser/dotnet-releaser.targets
@@ -100,6 +100,7 @@
       <_DotNetReleaserGetPackageInfo Include="$(IsPackable)" Kind="IsNuGetPackable"/>
       <_DotNetReleaserGetPackageInfo Include="$(IsTestProject)" Kind="IsTestProject"/>
       <_DotNetReleaserGetPackageInfo Include="@(ProjectReference)" Kind="ProjectReference"/>
+      <_DotNetReleaserGetPackageInfo Include="$([System.IO.Path]::GetFullPath('$(PublishDir)'))" Kind="PublishDir"/>
     </ItemGroup>
   </Target>
 
@@ -116,14 +117,14 @@
       <_DotNetReleaserPublishAndCreateRpm Include="$(RpmPath)" Kind="RpmPath"/>
     </ItemGroup>
   </Target>
-  <Target Name="DotNetReleaserPublishAndCreateZip" Outputs="@(_DotNetReleaserPublishAndCreateZip)" DependsOnTargets="CreateZip">
+  <Target Name="DotNetReleaserPublishAndCreateZip" Outputs="@(_DotNetReleaserPublishAndCreateZip)" DependsOnTargets="Publish">
     <ItemGroup>
-      <_DotNetReleaserPublishAndCreateZip Include="$(ZipPath)" Kind="ZipPath"/>
+      <_DotNetReleaserPublishAndCreateZip Include="$(PublishDir)" Kind="PublishDir"/>
     </ItemGroup>
   </Target>
-  <Target Name="DotNetReleaserPublishAndCreateTar" Outputs="@(_DotNetReleaserPublishAndCreateTar)" DependsOnTargets="CreateTarball">
+  <Target Name="DotNetReleaserPublishAndCreateTar" Outputs="@(_DotNetReleaserPublishAndCreateTar)" DependsOnTargets="Publish">
     <ItemGroup>
-      <_DotNetReleaserPublishAndCreateTar Include="$(TarballPath)" Kind="TarballPath"/>
+      <_DotNetReleaserPublishAndCreateTar Include="$(PublishDir)" Kind="PublishDir"/>
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
As detailed in #63, `dotnet-packaging` has an issue where executable bits are not set properly.

Instead of using `dotnet-packaging` for tar and zip creation, just use built-in .NET functions, which handles this case automatically for you. This removes the need for `dotnet-packaging` in these two instances.

I did not know what to do if the output file already existed, so I made that a failure case since there is a `--force` CLI option.

I also added a test case for this.

Fixes #63