### PR TITLE
Remove coverage publishing mention in read-me doc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,6 @@ In practice, `dotnet-releaser` will automate the build and publish process of yo
 - `dotnet nuget push` to publish your package to a NuGet registry
 - [Pretty changelog](https://github.com/xoofx/dotnet-releaser/blob/main/doc/changelog_user_guide.md#11-overview) creation from pull-requests and commits.
 - Create and upload the changelog and all the packages packed to your GitHub repository associated with the release tag.
-- It can publish automatically the coverage results to a badge in a GitHub gist or to https://coveralls.io if your repository is created there.
 - `dotnet-releaser` tool requires .NET 9.0 runtime to be installed.
   
 ![overview](https://raw.githubusercontent.com/xoofx/dotnet-releaser/main/doc/overview.drawio.svg)


### PR DESCRIPTION
Looks like Coveralls was removed with 655bc7bd18b15be853de07e9d1d2801abc877df1, but the read-me document still mentioned it. This PR removes that mention to avoid confusion.